### PR TITLE
Better name completion

### DIFF
--- a/gs-namecomplete/candy.js
+++ b/gs-namecomplete/candy.js
@@ -51,7 +51,7 @@ CandyShop.NameComplete = (function(self, Candy, $) {
 				// break it on spaces, and get the last word in the string
 				var field = $(this);
 				var msgParts = field.val().split(' ');
-				var lastWord = msgParts[msgParts.length - 1];
+				var lastWord = new RegExp( "^" + msgParts[msgParts.length - 1], "i");
 				var matches = [];
 
 				// go through each of the nicks and compare it


### PR DESCRIPTION
Hi there,

I made a change to the name completion so it behaves more like other jabber clients I have used. The changes are:
- Case insensitive test against the name
- Completion at the start of a line will also append a colon and space e.g. "Nickname: "
- Completion elsewhere in a line will only append a space e.g. "Nickname "

This is how tab completion would be expected to work in most IRC clients and this standard seems to have been carried into xmpp chat rooms.

Cheers,
Iain
