### PR TITLE
Fixed broken link in readme

### DIFF
--- a/inline-images/README.md
+++ b/inline-images/README.md
@@ -1,7 +1,7 @@
 # Inline Images
 If a user posts a URL to an image, that image gets rendered directly inside of Candy.
 
-![Inline Images](/inline-images/screenshot.png)
+![Inline Images](screenshot.png)
 
 ## Usage
 Include the JavaScript and CSS files:


### PR DESCRIPTION
The demo image was broken, probably as a result of [this change](https://help.github.com/articles/relative-links-in-readmes) dealing with relative links in readmes.

(what is the policy for pulls on this repo? it looks like the dev branch has totally different plugins in it right now. do new plugins go to dev but small fixes like this are okay on master? a contributor.md would definitely be helpful for both repos. just curious where I should send the reply plugin to when it's ready)
