### PR TITLE
Fix roomPanel display when using a pre-bind connection

### DIFF
--- a/roomPanel/roomPanel.js
+++ b/roomPanel/roomPanel.js
@@ -46,7 +46,8 @@ CandyShop.RoomPanel = (function(self, Candy, Strophe, $) {
 
         $(Candy).on('candy:core.chat.connection', {update: function(obj, data) {
             if (data.type == 'connection') {
-                if (Strophe.Status.CONNECTED == data.status) {
+                if (Strophe.Status.CONNECTED == data.status ||
+                    Strophe.Status.ATTACHED == data.status) {
                     /* only show room window if not already in a room, timeout is to let some time for auto join to execute */
                     setTimeout(CandyShop.RoomPanel.showRoomPanelIfAllClosed, 500);
                 } //if


### PR DESCRIPTION
As currently implemented, roomPanel will not display if a pre-bind connection was used instead of a regular connection.  This patch corrects the issue.
