### PR TITLE
Notifyme: use before-render & test whole message for nickname notification

### DIFF
--- a/notifyme/candy.js
+++ b/notifyme/candy.js
@@ -39,18 +39,18 @@ CandyShop.NotifyMe = (function(self, Candy, $) {
 		$.extend(true, _options, options);
 
 		// bind to the beforeShow event
-		$(Candy).on('candy:view.message.before-show', function(e, args) {
+		$(Candy).on('candy:view.message.before-render', function(e, args) {
 			// get the nick from the current user
 			var nick = Candy.Core.getUser().getNick();
 
 			// make it what is searched
-			// search for the name at the beginning of the message, or with a space in front
+			// search for <identifier>name in the whole message
 			var searchTerm = _options.nameIdentifier + nick;
-			var searchRegExp = new RegExp('(^' + searchTerm + '| ' + searchTerm + ')', 'ig');
+			var searchRegExp = new RegExp('^(.*)(' + searchTerm + '| ' + searchTerm + ')', 'ig');
 
 			// if it's in the message and it's not from me, do stuff
 			// I wouldn't want to say 'just do @{MY_NICK} to get my attention' and have it knock...
-			if (searchRegExp.test(args.message) && args.nick != nick) {
+			if (searchRegExp.test(args.templateData.message) && args.templateData.name != nick) {
 				// play the sound if specified
 				if (_options.playSound) {
 					Candy.View.Pane.Chat.Toolbar.playSound();
@@ -58,7 +58,7 @@ CandyShop.NotifyMe = (function(self, Candy, $) {
 
 				// highlight if specified
 				if (_options.highlightInRoom) {
-					args.message = args.message.replace(searchRegExp, '<span class="candy-notifyme-highlight">' + searchTerm + '</span>');
+					args.templateData.message = args.templateData.message.replace(searchRegExp, '$1<span class="candy-notifyme-highlight">' + searchTerm + '</span>');
 				}
 			}
 		});


### PR DESCRIPTION
@troymccabe what do you think about this change?

This will: 
1. not interfere with other plugins by doing format changes only before rendering
2. does check the whole message for `<identifier>nickname` (not only beginning of line + eventual space in front)

Related: #75 
