### PR TITLE
fix auto-invites for rooms with special characters

### DIFF
--- a/autojoininvites/autojoininvites.js
+++ b/autojoininvites/autojoininvites.js
@@ -22,7 +22,11 @@ CandyShop.AutoJoinInvites = (function(self, Candy, $) {
    */
   self.init = function(){
     $(Candy).on('candy:core:chat:invite',function(ev, obj) {
-      Candy.Core.Action.Jabber.Room.Join(obj.roomJid, null);
+      // JIDs in automatic invitations are escaped,
+      // but Room.Join expects unescaped JID
+      var roomJid = Candy.Util.unescapeJid(obj.roomJid);
+
+      Candy.Core.Action.Jabber.Room.Join(roomJid, null);
     })
   };
 


### PR DESCRIPTION
Currently, auto-invite doesn't work for rooms with special characters such as space.
The problem is, that `Room.Join` is made to simplify work of UI-implementors, who operate with unescpaped room-names.

Event, on the other hand, provides handler with escaped JID
