### PR TITLE
[inline-videos] fix listener in init.

### DIFF
--- a/inline-videos/candy.js
+++ b/inline-videos/candy.js
@@ -19,7 +19,7 @@ CandyShop.InlineVideos = (function(self, Candy, $) {
 	 */
 	self.init = function(options) {
 		// add a listener to these events
-		$(Candy.View.Pane).on('candy:view.message.beforeShow', self.handleBeforeShow);
+		$(Candy).on('candy:view.message.before-show', self.handleBeforeShow);
 	};
 	
 	/** Function: handleBeforeShow


### PR DESCRIPTION
$(Candy.View.Pane) is not working anymore to listen for events. Use $(Candy).on and change
event name to before-show.
