### PR TITLE
Optimization: Remove code duplication

### DIFF
--- a/notifyme/candy.js
+++ b/notifyme/candy.js
@@ -53,26 +53,7 @@ CandyShop.NotifyMe = (function(self, Candy, $) {
 		// apply the supplied options to the defaults specified
 		$.extend(true, _options, options);
 
-		// bind to the beforeShow event
-		$(Candy).on('candy:view.message.before-show', function(e, args) {
-			var searchRegExp = new RegExp('^(.*)(\s?' + _getSearchTerm() + ')', 'ig');
-
-			// if it's in the message and it's not from me, do stuff
-			// I wouldn't want to say 'just do @{MY_NICK} to get my attention' and have it knock...
-			if (searchRegExp.test(args.message) && args.name != _getNick()) {
-				// play the sound if specified
-				if (_options.playSound) {
-					Candy.View.Pane.Chat.Toolbar.playSound();
-				}
-
-				// Save that I'm mentioned in args
-				args.forMe = true;
-			}
-
-			return args.message;
-		});
-
-		// bind to the beforeShow event
+		// bind to the before-render event
 		$(Candy).on('candy:view.message.before-render', function(e, args) {
 			var searchTerm = _getSearchTerm();
 			var searchMatch = new RegExp('^(.*)(\s?' + searchTerm + ')', 'ig').exec(args.templateData.message);
@@ -88,6 +69,14 @@ CandyShop.NotifyMe = (function(self, Candy, $) {
 					}
 					args.templateData.message = args.templateData.message.replace(searchMatch[2], '<span class="candy-notifyme-highlight">' + displayNickName + '</span>');
 				}
+
+				// play the sound if specified
+				if (_options.playSound) {
+					Candy.View.Pane.Chat.Toolbar.playSound();
+				}
+
+				// Save that I'm mentioned in args
+				args.templateData.forMe = true;
 			}
 		});
 	};


### PR DESCRIPTION
This is more like a question:
Why did the notifyMe-plugin use two event-handlers? One to play a sound and set the forMe-flag in the message and one to modify the way it is displayed to the user.
This modification/PR merges it into one eventhandler.
Furthermore, I'm not sure what the forMe-flag is doing and if I moved it correctly. In the notification-plugin I read that it depends on NotifyMe but the forMe-flag occurs only once in the candy-plugins repo.