### PR TITLE
Restrict Height of Room List

### DIFF
--- a/notifications/candy.js
+++ b/notifications/candy.js
@@ -81,11 +81,18 @@ CandyShop.Notifications = (function(self, Candy, $) {
       if(_options.notifyNormalMessage ||
         (self.mentionsMe(args.message) && _options.notifyMention) ||
         (_options.notifyPersonalMessage && Candy.View.Pane.Chat.rooms[args.roomJid].type === 'chat')) {
+        
+        var message = args.message;
+        // If either of the color plugins are active, strip out the color span that they add
+        if ( 'undefined' != typeof CandyShop.ColorsXhtml || 'undefined' != typeof CandyShop.Colors ) {
+          message = /^<span style=\"color: #.*?>(.*)<\/span>$/g.exec(args.message)[1]
+        }
+        
         // Create the notification.
         var title = !_options.title ? args.name : _options.title ,
           notification = new window.Notification(title, {
           icon: _options.icon,
-          body: args.message,
+          body: message,
           requireInteraction: _options.requireInteraction
         });
 

--- a/roomPanel/README.md
+++ b/roomPanel/README.md
@@ -47,7 +47,10 @@ CandyShop.RoomPanel.init({
     autoDetectRooms: true,
 
     // how long in seconds before refreshing room list, default value is 600. [optional]
-    roomCacheTime: 600
+    roomCacheTime: 600,
+
+    // If this is set to an integer, the room list will be this many pixels tall (at most)
+    roomListMaxHeight: false,
 });
 
 Candy.Core.connect();

--- a/roomPanel/default.css
+++ b/roomPanel/default.css
@@ -2,6 +2,10 @@
     color: #333;
 }
 
+.roomList ul {
+	overflow: auto;
+}
+
 #roomPanel-control {
     width: 16px;
     background: url(images/room.png);

--- a/roomPanel/roomPanel.js
+++ b/roomPanel/roomPanel.js
@@ -130,9 +130,14 @@ CandyShop.RoomPanel = (function(self, Candy, Strophe, $) {
                     Candy.Core.getConnection().sendIQ(iq, self.updateRoomList);
                 } else {
 
+                    var listMaxHeight = '';
+                    if (_options.roomListMaxHeight) {
+                        listMaxHeight = ' style="max-height: ' + _options.roomListMaxHeight + 'px"';
+                    }
                     var html = Mustache.to_html(CandyShop.RoomPanel.Template.rooms, {
                             title: $.i18n._('candyshopRoomPanelChooseRoom'),
-                            roomList: _options.roomList
+                            roomList: _options.roomList,
+                            roomListMaxHeight: listMaxHeight
                     });
                     Candy.View.Pane.Chat.Modal.show(html,true);
 
@@ -174,7 +179,7 @@ CandyShop.RoomPanel.Template = (function (self) {
     var roomParts = [
         '<div class="roomList">',
             '<h2>{{title}}</h2>',
-            '<ul>',
+            '<ul{{roomListMaxHeight}}>',
                 '{{#roomList}}',
                     '<li><a href="#{{jid}}">{{name}}</a></li>',
                 '{{/roomList}}',


### PR DESCRIPTION
I needed to restrict the height of the Room List to help my mobile users see all the available rooms. Figured I'd update the plugin to do this and offer my changes.
